### PR TITLE
Prototype payment method types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.6.0</version>
+  <version>3.7.0</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>

--- a/src/main/java/io/electrum/vas/model/An32TokenPayment.java
+++ b/src/main/java/io/electrum/vas/model/An32TokenPayment.java
@@ -1,0 +1,57 @@
+package io.electrum.vas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.electrum.vas.Utils;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.Objects;
+
+@ApiModel(description = "Model for token-based payments", parent = PaymentMethod.class)
+public class An32TokenPayment extends PaymentMethod {
+
+   private String token = null;
+
+   @ApiModelProperty(required = true, value = "32 character alphanumeric code which identifies a token")
+   @JsonProperty("token")
+   @NotNull
+   @Pattern(regexp = "[a-zA-Z0-9]{32}")
+   public String getToken() {
+      return token;
+   }
+
+   public void setToken(String token) {
+      this.token = token;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, type, token);
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      An32TokenPayment otherToken = (An32TokenPayment) o;
+      return Objects.equals(this.type, otherToken.type)
+            && Objects.equals(this.token, otherToken.token);
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("class An32TokenPayment {\n");
+
+      sb.append("    type: ").append(Utils.toIndentedString(type)).append("\n");
+      sb.append("    token: ").append(Utils.toIndentedString(token)).append("\n");
+      sb.append("}");
+      return sb.toString();
+   }
+}

--- a/src/main/java/io/electrum/vas/model/BasicAdvice.java
+++ b/src/main/java/io/electrum/vas/model/BasicAdvice.java
@@ -18,7 +18,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * The data required in all value added service requests
  **/
-@ApiModel(description = "The data required in all value added service requests")
+@ApiModel(description = "The data required in all value added service requests", subTypes = {TenderAdvice.class, BasicReversal.class})
 public class BasicAdvice {
 
    protected String id;

--- a/src/main/java/io/electrum/vas/model/BasicReversal.java
+++ b/src/main/java/io/electrum/vas/model/BasicReversal.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
  * An advice that notifies of the negative completion of a transaction. This can be either due to customer cancellation,
  * or as a result of receiving a non-final response (or no response) to a request
  */
-@ApiModel(description = "An advice that notifies of the negative completion of a transaction. This can be either due to customer cancellation, or as a result of receiving a non-final response (or no response) to a request")
+@ApiModel(description = "An advice that notifies of the negative completion of a transaction. This can be either due to customer cancellation, or as a result of receiving a non-final response (or no response) to a request", parent = io.electrum.vas.model.BasicAdvice.class)
 public class BasicReversal extends BasicAdvice {
 
    public enum ReversalReason {

--- a/src/main/java/io/electrum/vas/model/LoyaltyCardPayment.java
+++ b/src/main/java/io/electrum/vas/model/LoyaltyCardPayment.java
@@ -1,0 +1,57 @@
+package io.electrum.vas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.electrum.vas.Utils;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.Objects;
+
+@ApiModel(description = "Model for payments made using loyalty programme cards", parent = PaymentMethod.class)
+public class LoyaltyCardPayment extends PaymentMethod {
+
+   private String cardNumber = null;
+
+   @ApiModelProperty(required = true, value = "Primary account number of the loyalty programme card used to make a payment")
+   @JsonProperty("cardNumber")
+   @NotNull
+   @Pattern(regexp = "[0-9]{16}")
+   public String getCardNumber() {
+      return cardNumber;
+   }
+
+   public void setCardNumber(String cardNumber) {
+      this.cardNumber = cardNumber;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(cardNumber, name, type);
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      LoyaltyCardPayment loyaltyCardPayment = (LoyaltyCardPayment) o;
+      return Objects.equals(this.type, loyaltyCardPayment.type)
+            && Objects.equals(this.cardNumber, loyaltyCardPayment.cardNumber);
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("class LoyaltyCardPayment {\n");
+
+      sb.append("    type: ").append(Utils.toIndentedString(type)).append("\n");
+      sb.append("    cardNumber: ").append(Utils.toIndentedString(cardNumber)).append("\n");
+      sb.append("}");
+      return sb.toString();
+   }
+}

--- a/src/main/java/io/electrum/vas/model/PaymentMethod.java
+++ b/src/main/java/io/electrum/vas/model/PaymentMethod.java
@@ -31,9 +31,8 @@ public class PaymentMethod {
 
    protected PaymentMethodType type = null;
 
-   @ApiModelProperty(required = true, value = "The specific method of payment used")
+   @ApiModelProperty(value = "The specific method of payment used")
    @JsonProperty("name")
-   @NotNull
    public String getName() {
       return name;
    }

--- a/src/main/java/io/electrum/vas/model/PaymentMethod.java
+++ b/src/main/java/io/electrum/vas/model/PaymentMethod.java
@@ -1,0 +1,84 @@
+package io.electrum.vas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.electrum.vas.Utils;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Objects;
+
+@ApiModel(description = "Base model for all payment types", discriminator = "type", subTypes = {An32TokenPayment.class, LoyaltyCardPayment.class})
+public class PaymentMethod {
+
+   public enum PaymentMethodType {
+      TOKEN("TOKEN"), LOYALTY_CARD("LOYALTY_CARD");
+
+      private String value;
+
+      PaymentMethodType(String value) {
+         this.value = value;
+      }
+
+      @Override
+      @JsonValue
+      public String toString() {
+         return String.valueOf(value);
+      }
+   }
+
+   protected PaymentMethodType type = null;
+
+   @ApiModelProperty(required = true, value = "The specific method pf payment used")
+   @JsonProperty("name")
+   @NotNull
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   protected String name;
+
+   @ApiModelProperty(required = true, value = "The general method pf payment used")
+   @JsonProperty("type")
+   @NotNull
+   public PaymentMethodType getType() {
+      return type;
+   }
+
+   public void setType(PaymentMethodType type) {
+      this.type = type;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(type);
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      PaymentMethod paymentMethod = (PaymentMethod) o;
+      return Objects.equals(this.type, paymentMethod.type);
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("class PaymentMethod {\n");
+      sb.append("    name: ").append(Utils.toIndentedString(type)).append("\n");
+      sb.append("    type: ").append(Utils.toIndentedString(type)).append("\n");
+      sb.append("}");
+      return sb.toString();
+   }
+}

--- a/src/main/java/io/electrum/vas/model/PaymentMethod.java
+++ b/src/main/java/io/electrum/vas/model/PaymentMethod.java
@@ -31,7 +31,7 @@ public class PaymentMethod {
 
    protected PaymentMethodType type = null;
 
-   @ApiModelProperty(required = true, value = "The specific method pf payment used")
+   @ApiModelProperty(required = true, value = "The specific method of payment used")
    @JsonProperty("name")
    @NotNull
    public String getName() {

--- a/src/main/java/io/electrum/vas/model/PaymentMethod.java
+++ b/src/main/java/io/electrum/vas/model/PaymentMethod.java
@@ -44,7 +44,7 @@ public class PaymentMethod {
 
    protected String name;
 
-   @ApiModelProperty(required = true, value = "The general method pf payment used")
+   @ApiModelProperty(required = true, value = "The general method of payment used")
    @JsonProperty("type")
    @NotNull
    public PaymentMethodType getType() {

--- a/src/main/java/io/electrum/vas/model/TenderAdvice.java
+++ b/src/main/java/io/electrum/vas/model/TenderAdvice.java
@@ -16,7 +16,7 @@ import javax.validation.Valid;
  * service implementations where additional information is present in the confirmation. Otherwise, a single message
  * implementation is preferable
  */
-@ApiModel(description = "An advice that notifies of the successful completion of a transaction.")
+@ApiModel(description = "An advice that notifies of the successful completion of a transaction.", parent = io.electrum.vas.model.BasicAdvice.class)
 public class TenderAdvice extends BasicAdvice {
 
    protected List<Tender> tenders = new ArrayList<>();


### PR DESCRIPTION
Add a base payment method model class with two sub-types: one for token-based payments and one for loyalty card based payments.

Also added the necessary Swagger annotations to simulate/model inheritance relationships to BasicAdvice, BasicReversal and TenderAdvice. However, since no discriminator is defined, it will not be modeled with inheritance: the sub-types of BasicAdvice will simply have all the same fields as BasicAdvice in the generated Swagger spec.