### PR TITLE
Removed warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ version: 2
 jobs:
   build-and-release:
     docker:
-      - image: electrum-docker.jfrog.io/circleci-openjdk
+      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk
         auth:
-          username: circleci-reader
+          username: $ARTIFACTORY_READER_USERNAME
           password: $ARTIFACTORY_READER_PASSWORD
     steps:
       - setup_remote_docker
@@ -51,12 +51,11 @@ jobs:
           destination: release
   code-coverage-report:
     docker:
-      - image: electrum-docker.jfrog.io/circleci-openjdk
+      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk
         auth:
-          username: circleci-reader
+          username: $ARTIFACTORY_READER_USERNAME
           password: $ARTIFACTORY_READER_PASSWORD
     steps:
-      - setup_remote_docker
       - run:
           name: Sonar Checkout
           command: /electrum/bin/sonarCheckout.sh
@@ -76,9 +75,9 @@ jobs:
           destination: coverage
   build-with-latest-deps:
     docker:
-      - image: electrum-docker.jfrog.io/circleci-openjdk
+      - image: ${ARTIFACTORY_DOCKER_URL}/circleci-openjdk
         auth:
-          username: circleci-reader
+          username: $ARTIFACTORY_READER_USERNAME
           password: $ARTIFACTORY_READER_PASSWORD
     steps:
       - setup_remote_docker

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.28.0</version>
+  <version>3.29.0</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>
@@ -34,14 +34,15 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <message-masking-sdk-version>2.1.0</message-masking-sdk-version>
-    <joda-time-version>2.9.4</joda-time-version>
+    <joda-time-version>2.10.5</joda-time-version>
     <swagger-version>1.5.19</swagger-version>
     <hibernate-validator-version>5.4.3.Final</hibernate-validator-version>
-    <jackson-datatype-joda-version>2.9.5</jackson-datatype-joda-version>
-    <jackson-datatype-jdk8-version>2.8.5</jackson-datatype-jdk8-version>
-    <jackson-datatype-jsr310-version>2.8.5</jackson-datatype-jsr310-version>
+    <jackson-datatype-joda-version>2.10.0</jackson-datatype-joda-version>
+    <jackson-datatype-jdk8-version>2.11.2</jackson-datatype-jdk8-version>
+    <jackson-datatype-jsr310-version>2.11.2</jackson-datatype-jsr310-version>
     <el-version>3.0.0</el-version>
-    <jaxb-version>2.2.11</jaxb-version>
+    <jaxb-version>2.3.1</jaxb-version>
+    <jaxb-core-version>2.3.0</jaxb-core-version>
     <testng-version>7.0.0</testng-version>
     <mockito-core-version>2.25.0</mockito-core-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
@@ -100,7 +101,7 @@
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>${jaxb-version}</version>
+      <version>${jaxb-core-version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
@@ -153,7 +154,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
         <configuration>
           <failOnError>false</failOnError>
           <source>8</source>
@@ -162,7 +163,7 @@
       <plugin>
         <groupId>com.github.kongchen</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.8</version>
         <configuration>
           <apiSources>
             <apiSource>
@@ -219,7 +220,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.4.0</version>
+        <version>1.6.0</version>
         <executions>
           <execution>
             <id>build-devguide</id>
@@ -344,6 +345,7 @@
         <!--Use testng.xml for test configuration -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
         <configuration>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>


### PR DESCRIPTION
*There were a bunch of warnings that were really irritating me after the move to compile on Java 11 so I have fixed them.
*I also updated a bunch of other plugins and the docker image that we are building from.

The warnings were:
```
[WARNING] The POM for com.sun.xml.bind:jaxb-core:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for com.sun.xml.bind:jaxb-impl:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
```
and they are generated by the gateway plugins that implement Java 11 compiled service-interfaces.