### PR TITLE
Added new `Address` model object and added use of it to the `Customer` model object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include this package in your service interface definitions, include the below
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>service-interface-base</artifactId>
-    <version>3.29.0</version>
+    <version>3.30.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.30.0</version>
+  <version>3.30.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.30.0-SNAPSHOT</version>
+  <version>3.30.0</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.29.0</version>
+  <version>3.30.0</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,7 +14,7 @@
     - Try and avoid special characters as far as possible
 -->
 
-## Version 3.30.0 - 07 April 2021
+## Version 3.30.0 - 29 April 2021
 ### New Features
 * Added new `Address` model object that contains a detailed breakdown of an address.
 * Added new member variable called `addressDetails` to the `Customer` model object.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,21 @@
+# Service Interface Base Release Notes
+
+<!-- README:
+  * Add new entries to the top of this file (under this comment), making sure to specify the correct version number and release date.
+  * Make sure you include a concise description of all changes since the previous release. Check the git history to be sure.
+  * Group the descriptions under the relevant headings (but don’t include a heading if there are no changes under it):
+    - Breaking Changes -> Changes that break backwards compatability. These will correspond to a major version release.
+    - New Features -> Changes that would, in the absence of any breaking changes, constitute a minor version release.
+    - Fixed -> Bugfixes that would, in the absence of any new features or breaking changes, constitute a patch version release.
+    - Deprecated -> Any classes or methods that have been deprecated.
+  * Make use of Markdown formatting:
+    - Run ‘$curl cheat.sh/markdown’ from your command line to get a quick overview of markdown.
+    - Use the convention of enclosing class, variable and method names in backticks so that they render as monospace.
+    - Try and avoid special characters as far as possible
+-->
+
+## Version 3.30.0 - 07 April 2021
+### New Features
+* Added new `Address` model object that contains a detailed breakdown of an address.
+* Added new member variable called `addressDetails` to the `Customer` model object.
+* Deprecated the existing `address` member variable as it will be replaced by the new `addressDetails` member variable.

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,6 +17,6 @@
 ## Version 3.30.0 - 29 April 2021
 ### New Features
 * Added new `Address` model object that contains a detailed breakdown of an address.
-* Added new member variable called `addressDetails` to the `Customer` model object.
+* Added new member variables called `addressDetails` and `profileId` to the `Customer` model object.
 * Deprecated the existing `address` member variable as it will be replaced by the new `addressDetails` member variable.
 * Refactored the tests a bit so that they are easier to read and add to.

--- a/release-notes.md
+++ b/release-notes.md
@@ -19,3 +19,4 @@
 * Added new `Address` model object that contains a detailed breakdown of an address.
 * Added new member variable called `addressDetails` to the `Customer` model object.
 * Deprecated the existing `address` member variable as it will be replaced by the new `addressDetails` member variable.
+* Refactored the tests a bit so that they are easier to read and add to.

--- a/src/main/java/io/electrum/vas/model/Address.java
+++ b/src/main/java/io/electrum/vas/model/Address.java
@@ -7,8 +7,7 @@ import io.electrum.vas.Utils;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.Pattern;
 import java.util.Objects;
 
 /**
@@ -27,14 +26,14 @@ public class Address {
    @JsonProperty("city")
    private String city = null;
 
-   @JsonProperty("province")
-   private String province = null;
+   @JsonProperty("region")
+   private String region = null;
 
    @JsonProperty("country")
    private String country = null;
 
-   @JsonProperty("postCode")
-   private String postCode = null;
+   @JsonProperty("postalCode")
+   private String postalCode = null;
 
    public Address addressLine1(String addressLine1) {
       this.addressLine1 = addressLine1;
@@ -48,7 +47,7 @@ public class Address {
     **/
    @JsonProperty("addressLine1")
    @ApiModelProperty(value = "First line of street address.")
-   @Size(max = 50)
+   @Pattern(regexp="^.{1,250}")
    @Masked
    public String getAddressLine1() {
       return addressLine1;
@@ -70,7 +69,7 @@ public class Address {
     **/
    @JsonProperty("addressLine2")
    @ApiModelProperty(value = "Second line of street address (if required).")
-   @Size(max = 50)
+   @Pattern(regexp="^.{1,250}")
    @Masked
    public String getAddressLine2() {
       return addressLine2;
@@ -91,8 +90,8 @@ public class Address {
     * @return city
     **/
    @JsonProperty("city")
-   @ApiModelProperty(value = "")
-   @Size(max = 50)
+   @ApiModelProperty(value = "The city where the owner is located. Note: if this field ever needs to be translated to another API with shorter fields, the field will be truncated from the right.")
+   @Pattern(regexp="^.{1,30}")
    @Masked
    public String getCity() {
       return city;
@@ -102,26 +101,26 @@ public class Address {
       this.city = city;
    }
 
-   public Address province(String province) {
-      this.province = province;
+   public Address region(String region) {
+      this.region = region;
       return this;
    }
 
    /**
-    * Get province
+    * Get region
     * 
-    * @return province
+    * @return region
     **/
-   @JsonProperty("province")
-   @ApiModelProperty(value = "")
-   @Size(max = 50)
+   @JsonProperty("region")
+   @ApiModelProperty(value = "The state or region where the owner is located.")
+   @Pattern(regexp="[A-Z]{2}")
    @Masked
-   public String getProvince() {
-      return province;
+   public String getRegion() {
+      return region;
    }
 
-   public void setProvince(String province) {
-      this.province = province;
+   public void setRegion(String region) {
+      this.region = region;
    }
 
    public Address country(String country) {
@@ -135,9 +134,8 @@ public class Address {
     * @return country
     **/
    @JsonProperty("country")
-   @ApiModelProperty(value = "Country expressed as an ISO 3166-1 Alpha-2 code")
-   @Valid
-   @Size(min = 2, max = 2)
+   @ApiModelProperty(value = "The owner's resident country expressed as an ISO 3166-1 Alpha-2 code.")
+   @Pattern(regexp="[A-Z]{2}")
    @Masked
    public String getCountry() {
       return country;
@@ -147,26 +145,26 @@ public class Address {
       this.country = country;
    }
 
-   public Address postCode(String postCode) {
-      this.postCode = postCode;
+   public Address postalCode(String postalCode) {
+      this.postalCode = postalCode;
       return this;
    }
 
    /**
-    * Get postCode
+    * Get postalCode
     * 
-    * @return postCode
+    * @return postalCode
     **/
-   @JsonProperty("postCode")
-   @ApiModelProperty(value = "")
-   @Size(max = 10)
+   @JsonProperty("postalCode")
+   @ApiModelProperty(value = "The owner's postal code.")
+   @Pattern(regexp="[A-Za-z0-9 -]{1,20}")
    @Masked
-   public String getPostCode() {
-      return postCode;
+   public String getPostalCode() {
+      return postalCode;
    }
 
-   public void setPostCode(String postCode) {
-      this.postCode = postCode;
+   public void setPostalCode(String postalCode) {
+      this.postalCode = postalCode;
    }
 
    @Override
@@ -180,13 +178,13 @@ public class Address {
       Address address = (Address) o;
       return Objects.equals(this.addressLine1, address.addressLine1)
             && Objects.equals(this.addressLine2, address.addressLine2) && Objects.equals(this.city, address.city)
-            && Objects.equals(this.province, address.province) && Objects.equals(this.country, address.country)
-            && Objects.equals(this.postCode, address.postCode);
+            && Objects.equals(this.region, address.region) && Objects.equals(this.country, address.country)
+            && Objects.equals(this.postalCode, address.postalCode);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(addressLine1, addressLine2, city, province, country, postCode);
+      return Objects.hash(addressLine1, addressLine2, city, region, country, postalCode);
    }
 
    @Override
@@ -197,9 +195,9 @@ public class Address {
       sb.append("    addressLine1: ").append(Utils.toIndentedString(new MaskAll().mask(addressLine1))).append("\n");
       sb.append("    addressLine2: ").append(Utils.toIndentedString(new MaskAll().mask(addressLine2))).append("\n");
       sb.append("    city: ").append(Utils.toIndentedString(new MaskAll().mask(city))).append("\n");
-      sb.append("    province: ").append(Utils.toIndentedString(new MaskAll().mask(province))).append("\n");
+      sb.append("    region: ").append(Utils.toIndentedString(new MaskAll().mask(region))).append("\n");
       sb.append("    country: ").append(Utils.toIndentedString(new MaskAll().mask(country))).append("\n");
-      sb.append("    postCode: ").append(Utils.toIndentedString(new MaskAll().mask(postCode))).append("\n");
+      sb.append("    postalCode: ").append(Utils.toIndentedString(new MaskAll().mask(postalCode))).append("\n");
       sb.append("}");
       return sb.toString();
    }

--- a/src/main/java/io/electrum/vas/model/Address.java
+++ b/src/main/java/io/electrum/vas/model/Address.java
@@ -1,19 +1,15 @@
 package io.electrum.vas.model;
 
-import java.util.Objects;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.electrum.sdk.masking2.MaskAll;
 import io.electrum.sdk.masking2.Masked;
 import io.electrum.vas.Utils;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.Objects;
 
 /**
  * Details of a customer's address

--- a/src/main/java/io/electrum/vas/model/Address.java
+++ b/src/main/java/io/electrum/vas/model/Address.java
@@ -3,6 +3,8 @@ package io.electrum.vas.model;
 import java.util.Objects;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,6 +52,7 @@ public class Address {
     **/
    @JsonProperty("addressLine1")
    @ApiModelProperty(value = "First line of street address.")
+   @Size(max = 50)
    @Masked
    public String getAddressLine1() {
       return addressLine1;
@@ -71,6 +74,7 @@ public class Address {
     **/
    @JsonProperty("addressLine2")
    @ApiModelProperty(value = "Second line of street address (if required).")
+   @Size(max = 50)
    @Masked
    public String getAddressLine2() {
       return addressLine2;
@@ -92,6 +96,7 @@ public class Address {
     **/
    @JsonProperty("city")
    @ApiModelProperty(value = "")
+   @Size(max = 50)
    @Masked
    public String getCity() {
       return city;
@@ -113,6 +118,7 @@ public class Address {
     **/
    @JsonProperty("province")
    @ApiModelProperty(value = "")
+   @Size(max = 50)
    @Masked
    public String getProvince() {
       return province;
@@ -157,6 +163,7 @@ public class Address {
     **/
    @JsonProperty("postCode")
    @ApiModelProperty(value = "")
+   @Size(max = 10)
    @Masked
    public String getPostCode() {
       return postCode;

--- a/src/main/java/io/electrum/vas/model/Address.java
+++ b/src/main/java/io/electrum/vas/model/Address.java
@@ -1,0 +1,203 @@
+package io.electrum.vas.model;
+
+import java.util.Objects;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.electrum.sdk.masking2.MaskAll;
+import io.electrum.sdk.masking2.Masked;
+import io.electrum.vas.Utils;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * Details of a customer's address
+ *
+ * @since 3.30.0
+ */
+@ApiModel(description = "Details of a customer's address")
+public class Address {
+   @JsonProperty("addressLine1")
+   private String addressLine1 = null;
+
+   @JsonProperty("addressLine2")
+   private String addressLine2 = null;
+
+   @JsonProperty("city")
+   private String city = null;
+
+   @JsonProperty("province")
+   private String province = null;
+
+   @JsonProperty("country")
+   private String country = null;
+
+   @JsonProperty("postCode")
+   private String postCode = null;
+
+   public Address addressLine1(String addressLine1) {
+      this.addressLine1 = addressLine1;
+      return this;
+   }
+
+   /**
+    * First line of street address.
+    * 
+    * @return addressLine1
+    **/
+   @JsonProperty("addressLine1")
+   @ApiModelProperty(value = "First line of street address.")
+   @Masked
+   public String getAddressLine1() {
+      return addressLine1;
+   }
+
+   public void setAddressLine1(String addressLine1) {
+      this.addressLine1 = addressLine1;
+   }
+
+   public Address addressLine2(String addressLine2) {
+      this.addressLine2 = addressLine2;
+      return this;
+   }
+
+   /**
+    * Second line of street address (if required).
+    * 
+    * @return addressLine2
+    **/
+   @JsonProperty("addressLine2")
+   @ApiModelProperty(value = "Second line of street address (if required).")
+   @Masked
+   public String getAddressLine2() {
+      return addressLine2;
+   }
+
+   public void setAddressLine2(String addressLine2) {
+      this.addressLine2 = addressLine2;
+   }
+
+   public Address city(String city) {
+      this.city = city;
+      return this;
+   }
+
+   /**
+    * Get city
+    * 
+    * @return city
+    **/
+   @JsonProperty("city")
+   @ApiModelProperty(value = "")
+   @Masked
+   public String getCity() {
+      return city;
+   }
+
+   public void setCity(String city) {
+      this.city = city;
+   }
+
+   public Address province(String province) {
+      this.province = province;
+      return this;
+   }
+
+   /**
+    * Get province
+    * 
+    * @return province
+    **/
+   @JsonProperty("province")
+   @ApiModelProperty(value = "")
+   @Masked
+   public String getProvince() {
+      return province;
+   }
+
+   public void setProvince(String province) {
+      this.province = province;
+   }
+
+   public Address country(String country) {
+      this.country = country;
+      return this;
+   }
+
+   /**
+    * Country expressed as an ISO 3166-1 Alpha-2 code
+    * 
+    * @return country
+    **/
+   @JsonProperty("country")
+   @ApiModelProperty(value = "Country expressed as an ISO 3166-1 Alpha-2 code")
+   @Valid
+   @Size(min = 2, max = 2)
+   @Masked
+   public String getCountry() {
+      return country;
+   }
+
+   public void setCountry(String country) {
+      this.country = country;
+   }
+
+   public Address postCode(String postCode) {
+      this.postCode = postCode;
+      return this;
+   }
+
+   /**
+    * Get postCode
+    * 
+    * @return postCode
+    **/
+   @JsonProperty("postCode")
+   @ApiModelProperty(value = "")
+   @Masked
+   public String getPostCode() {
+      return postCode;
+   }
+
+   public void setPostCode(String postCode) {
+      this.postCode = postCode;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+         return false;
+      }
+      Address address = (Address) o;
+      return Objects.equals(this.addressLine1, address.addressLine1)
+            && Objects.equals(this.addressLine2, address.addressLine2) && Objects.equals(this.city, address.city)
+            && Objects.equals(this.province, address.province) && Objects.equals(this.country, address.country)
+            && Objects.equals(this.postCode, address.postCode);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(addressLine1, addressLine2, city, province, country, postCode);
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("class Address {\n");
+
+      sb.append("    addressLine1: ").append(Utils.toIndentedString(new MaskAll().mask(addressLine1))).append("\n");
+      sb.append("    addressLine2: ").append(Utils.toIndentedString(new MaskAll().mask(addressLine2))).append("\n");
+      sb.append("    city: ").append(Utils.toIndentedString(new MaskAll().mask(city))).append("\n");
+      sb.append("    province: ").append(Utils.toIndentedString(new MaskAll().mask(province))).append("\n");
+      sb.append("    country: ").append(Utils.toIndentedString(new MaskAll().mask(country))).append("\n");
+      sb.append("    postCode: ").append(Utils.toIndentedString(new MaskAll().mask(postCode))).append("\n");
+      sb.append("}");
+      return sb.toString();
+   }
+}

--- a/src/main/java/io/electrum/vas/model/Customer.java
+++ b/src/main/java/io/electrum/vas/model/Customer.java
@@ -29,6 +29,7 @@ public class Customer {
    private String msisdn = null;
    private String emailAddress = null;
    private Address addressDetails = null;
+   private String profileId = null;
 
    /**
     * The customer's first name(s)
@@ -223,6 +224,25 @@ public class Customer {
       this.emailAddress = emailAddress;
    }
 
+   /**
+    * TODO:
+    */
+   public Customer profileId(String profileId) {
+      this.profileId = profileId;
+      return this;
+   }
+
+   @ApiModelProperty(value = /*TODO*/"")
+   @Email
+   @JsonProperty("profileId")
+   public String getProfileId() {
+      return profileId;
+   }
+
+   public void setProfileId(String profileId) {
+      this.profileId = profileId;
+   }
+
    @Override
    public boolean equals(Object o) {
       if (this == o) {
@@ -235,12 +255,12 @@ public class Customer {
       return Objects.equals(firstName, customer.firstName) && Objects.equals(lastName, customer.lastName)
             && Objects.equals(address, customer.address) && Objects.equals(dateOfBirth, customer.dateOfBirth)
             && Objects.equals(status, customer.status) && Objects.equals(msisdn, customer.msisdn)
-            && Objects.equals(emailAddress, customer.emailAddress);
+            && Objects.equals(emailAddress, customer.emailAddress) && Objects.equals(profileId, customer.profileId);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(firstName, lastName, address, dateOfBirth, status, msisdn, emailAddress);
+      return Objects.hash(firstName, lastName, address, dateOfBirth, status, msisdn, emailAddress, profileId);
    }
 
    @Override
@@ -255,6 +275,7 @@ public class Customer {
       sb.append("    status: ").append(Utils.toIndentedString(status)).append("\n");
       sb.append("    msisdn: ").append(Utils.toIndentedString(msisdn)).append("\n");
       sb.append("    emailAddress: ").append(Utils.toIndentedString(emailAddress)).append("\n");
+      sb.append("    profileId: ").append(Utils.toIndentedString(profileId)).append("\n");
       sb.append("}");
       return sb.toString();
    }

--- a/src/main/java/io/electrum/vas/model/Customer.java
+++ b/src/main/java/io/electrum/vas/model/Customer.java
@@ -28,6 +28,7 @@ public class Customer {
    private String status = null;
    private String msisdn = null;
    private String emailAddress = null;
+   private Address addressDetails = null;
 
    /**
     * The customer's first name(s)
@@ -69,21 +70,81 @@ public class Customer {
 
    /**
     * The customer's address
+    *
+    * @deprecated The {@link io.electrum.vas.model.Customer#address} member variable of type {@link String} has been
+    *             replaced with a more detailed member variable of type {@link Address} called
+    *             {@link io.electrum.vas.model.Customer#addressDetails}.
+    *             <p> Use {@link io.electrum.vas.model.Customer#addressDetails(Address)} instead
+    *
     **/
+   @Deprecated(/*since = "3.30.0", forRemoval = true*/)
    public Customer address(String address) {
       this.address = address;
       return this;
    }
 
+   /**
+    * Get the customer's address
+    *
+    * @deprecated The {@link io.electrum.vas.model.Customer#address} member variable of type {@link String} has been
+    *             replaced with a more detailed member variable of type {@link Address} called
+    *             {@link io.electrum.vas.model.Customer#addressDetails}.
+    *             <p> Use {@link Customer#getAddressDetails()} instead
+    *
+    **/
    @ApiModelProperty(value = "The customer's address")
    @JsonProperty("address")
    @Length(max = 80)
+   @Deprecated(/*since = "3.30.0", forRemoval = true*/)
    public String getAddress() {
       return address;
    }
 
+   /**
+    * Set the customer's address
+    *
+    * @deprecated The {@link io.electrum.vas.model.Customer#address} member variable of type {@link String} has been
+    *             replaced with a more detailed member variable of type {@link Address} called
+    *             {@link io.electrum.vas.model.Customer#addressDetails}.
+    *             <p> Use {@link io.electrum.vas.model.Customer#setAddressDetails(Address)} instead
+    *
+    **/
+   @Deprecated(/*since = "3.30.0", forRemoval = true*/)
    public void setAddress(String address) {
       this.address = address;
+   }
+
+   /**
+    * The customer's address details
+    *
+    * @since 3.30.0
+    *
+    * @return addressDetails
+    **/
+   public Customer addressDetails(Address addressDetails) {
+      this.addressDetails = addressDetails;
+      return this;
+   }
+
+   /**
+    * @since v3.30.0
+    *
+    * @return addressDetails instance
+    */
+   @JsonProperty("addressDetails")
+   @ApiModelProperty(value = "")
+   @Valid
+   public Address getAddressDetails() {
+      return addressDetails;
+   }
+
+   /**
+    * @since v3.30.0
+    *
+    * @param address
+    */
+   public void setAddressDetails(Address address) {
+      this.addressDetails = addressDetails;
    }
 
    /**

--- a/src/main/java/io/electrum/vas/model/Customer.java
+++ b/src/main/java/io/electrum/vas/model/Customer.java
@@ -116,7 +116,7 @@ public class Customer {
    }
 
    /**
-    * The customer's address details
+    * The customer's address details.
     *
     * @since 3.30.0
     *
@@ -133,7 +133,7 @@ public class Customer {
     * @return addressDetails instance
     */
    @JsonProperty("addressDetails")
-   @ApiModelProperty(value = "")
+   @ApiModelProperty(value = "The customer's address details.")
    @Valid
    public Address getAddressDetails() {
       return addressDetails;
@@ -142,9 +142,9 @@ public class Customer {
    /**
     * @since v3.30.0
     *
-    * @param address
+    * @param addressDetails
     */
-   public void setAddressDetails(Address address) {
+   public void setAddressDetails(Address addressDetails) {
       this.addressDetails = addressDetails;
    }
 
@@ -225,15 +225,14 @@ public class Customer {
    }
 
    /**
-    * TODO:
+    * The customer's profile ID. Used to uniquely identify a customer.
     */
    public Customer profileId(String profileId) {
       this.profileId = profileId;
       return this;
    }
 
-   @ApiModelProperty(value = /*TODO*/"")
-   @Email
+   @ApiModelProperty(required = false, value = "The customer's profile ID. Used to uniquely identify a customer.")
    @JsonProperty("profileId")
    public String getProfileId() {
       return profileId;
@@ -253,14 +252,16 @@ public class Customer {
       }
       Customer customer = (Customer) o;
       return Objects.equals(firstName, customer.firstName) && Objects.equals(lastName, customer.lastName)
-            && Objects.equals(address, customer.address) && Objects.equals(dateOfBirth, customer.dateOfBirth)
-            && Objects.equals(status, customer.status) && Objects.equals(msisdn, customer.msisdn)
-            && Objects.equals(emailAddress, customer.emailAddress) && Objects.equals(profileId, customer.profileId);
+            && Objects.equals(address, customer.address) && Objects.equals(addressDetails, customer.addressDetails)
+            && Objects.equals(dateOfBirth, customer.dateOfBirth) && Objects.equals(status, customer.status)
+            && Objects.equals(msisdn, customer.msisdn) && Objects.equals(emailAddress, customer.emailAddress)
+            && Objects.equals(profileId, customer.profileId);
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash(firstName, lastName, address, dateOfBirth, status, msisdn, emailAddress, profileId);
+      return Objects
+            .hash(firstName, lastName, address, addressDetails, dateOfBirth, status, msisdn, emailAddress, profileId);
    }
 
    @Override
@@ -271,6 +272,7 @@ public class Customer {
       sb.append("    firstName: ").append(Utils.toIndentedString(firstName)).append("\n");
       sb.append("    lastName: ").append(Utils.toIndentedString(lastName)).append("\n");
       sb.append("    address: ").append(Utils.toIndentedString(address)).append("\n");
+      sb.append("    addressDetails: ").append(Utils.toIndentedString(addressDetails)).append("\n");
       sb.append("    dateOfBirth: ").append(Utils.toIndentedString(dateOfBirth)).append("\n");
       sb.append("    status: ").append(Utils.toIndentedString(status)).append("\n");
       sb.append("    msisdn: ").append(Utils.toIndentedString(msisdn)).append("\n");

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -161,7 +161,8 @@ public class NewModelTests {
               {rewardPayment, JsonUtil.readFileAsString(PayloadFileLocations.REWARD_PAYMENT, false)},
               {originator, JsonUtil.readFileAsString(PayloadFileLocations.ORIGINATOR, false)},
               {walletPayment, JsonUtil.readFileAsString(PayloadFileLocations.WALLET_PAYMENT, false)},
-              {cardPayment, JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false)}
+              {cardPayment, JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false)},
+              {address, JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false)}
               //@formatter:on
       };
    }
@@ -195,7 +196,8 @@ public class NewModelTests {
               {rewardPayment},
               {originator},
               {walletPayment},
-              {cardPayment}
+              {cardPayment},
+              {address}
               //@formatter:on
       };
    }
@@ -211,7 +213,8 @@ public class NewModelTests {
               {JsonUtil.readFileAsString(PayloadFileLocations.REWARD_PAYMENT, false), RewardPayment.class},
               {JsonUtil.readFileAsString(PayloadFileLocations.ORIGINATOR, false), Originator.class},
               {JsonUtil.readFileAsString(PayloadFileLocations.WALLET_PAYMENT, false), WalletPayment.class},
-              {JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false), CardPayment.class}
+              {JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false), CardPayment.class},
+              {JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false), Address.class}
               //@formatter:on
       };
    }
@@ -269,7 +272,14 @@ public class NewModelTests {
                       .proxy("12345").proxyType(ProxyType.UNKNOWN).pin(new PinEncrypted()),
                       new CardPayment().pan("1234567891234567891").amount(new LedgerAmount().amount(456L).currency(
                               "710")).name("Card Payment")
-                      .issuer(new Institution().id("1234InsId").name("Institution")).proxy(null).proxyType(ProxyType.UNKNOWN)}
+                      .issuer(new Institution().id("1234InsId").name("Institution")).proxy(null).proxyType(ProxyType.UNKNOWN)},
+              {new Address()
+                    .addressLine1("41 Sheila Street")
+                    .addressLine2("Edenvale")
+                    .city("Johannesburg")
+                    .province("Gauteng")
+                    .country("South Africa")
+                    .postCode("1609"), address}
               //@formatter:on
       };
    }

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -281,5 +281,4 @@ public class NewModelTests {
               //@formatter:on
       };
    }
-
 }

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -43,7 +43,7 @@ public class NewModelTests {
                   .addressLine1("41 Sheila Street")
                   .addressLine2("Edenvale")
                   .city("Johannesburg")
-                  .region("Gauteng")
+                  .region("GP")
                   .country("ZA")
                   .postalCode("1609"))
             .profileId("188a66d6-166f-4010-9a8e-ea4d3bb22a09");
@@ -52,7 +52,7 @@ public class NewModelTests {
             .addressLine1("41 Sheila Street")
             .addressLine2("Edenvale")
             .city("Johannesburg")
-            .region("Gauteng")
+            .region("GP")
             .country("ZA")
             .postalCode("1609");
 
@@ -276,7 +276,7 @@ public class NewModelTests {
                     .addressLine2("Edenvale")
                     .city("Johannesburg")
                     .region("Gauteng")
-                    .country("South Africa")
+                    .country("ZA")
                     .postalCode("1609"), address}
               //@formatter:on
       };

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -1,13 +1,6 @@
 package io.electrum.vas.model;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-
+import io.electrum.vas.JsonUtil;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -17,7 +10,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import io.electrum.vas.JsonUtil;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
 
 public class NewModelTests {
 
@@ -45,18 +43,18 @@ public class NewModelTests {
                   .addressLine1("41 Sheila Street")
                   .addressLine2("Edenvale")
                   .city("Johannesburg")
-                  .province("Gauteng")
+                  .region("Gauteng")
                   .country("ZA")
-                  .postCode("1609"))
+                  .postalCode("1609"))
             .profileId("188a66d6-166f-4010-9a8e-ea4d3bb22a09");
 
       address = new Address()
             .addressLine1("41 Sheila Street")
             .addressLine2("Edenvale")
             .city("Johannesburg")
-            .province("Gauteng")
+            .region("Gauteng")
             .country("ZA")
-            .postCode("1609");
+            .postalCode("1609");
 
       originator = new Originator()
             .operatorId("someOperatorID");
@@ -277,9 +275,9 @@ public class NewModelTests {
                     .addressLine1("41 Sheila Street")
                     .addressLine2("Edenvale")
                     .city("Johannesburg")
-                    .province("Gauteng")
+                    .region("Gauteng")
                     .country("South Africa")
-                    .postCode("1609"), address}
+                    .postalCode("1609"), address}
               //@formatter:on
       };
    }

--- a/src/test/java/io/electrum/vas/model/PayloadFileLocations.java
+++ b/src/test/java/io/electrum/vas/model/PayloadFileLocations.java
@@ -1,0 +1,15 @@
+package io.electrum.vas.model;
+
+public class PayloadFileLocations {
+   private PayloadFileLocations() {
+
+   }
+   public static final String PIN_HASHED = "models/PinHashed.json";
+   public static final String BASIC_ADVICE = "models/BasicAdvice.json";
+   public static final String ORIGINATOR = "models/Originator.json";
+   public static final String REWARD_PAYMENT = "models/RewardPayment.json";
+   public static final String WALLET_PAYMENT = "models/WalletPayment.json";
+   public static final String CARD_PAYMENT = "models/CardPayment.json";
+   public static final String CUSTOMER = "models/Customer.json";
+   public static final String ADDRESS = "models/Address.json";
+}

--- a/src/test/resources/messages/models/Address.json
+++ b/src/test/resources/messages/models/Address.json
@@ -2,7 +2,7 @@
   "addressLine1":"41 Sheila Street",
   "addressLine2":"Edenvale",
   "city":"Johannesburg",
-  "province":"Gauteng",
+  "region":"GP",
   "country":"ZA",
-  "postCode":"1609"
+  "postalCode":"1609"
 }

--- a/src/test/resources/messages/models/Address.json
+++ b/src/test/resources/messages/models/Address.json
@@ -1,0 +1,8 @@
+{
+  "addressLine1":"41 Sheila Street",
+  "addressLine2":"Edenvale",
+  "city":"Johannesburg",
+  "province":"Gauteng",
+  "country":"ZA",
+  "postCode":"1609"
+}

--- a/src/test/resources/messages/models/BasicAdvice.json
+++ b/src/test/resources/messages/models/BasicAdvice.json
@@ -1,0 +1,20 @@
+{
+  "id":"123456ID",
+  "requestId":"requestId1",
+  "time":"2013-06-07T10:11:59.000Z",
+  "thirdPartyIdentifiers":[
+    {
+      "institutionId":"1234InsId",
+      "transactionIdentifier":"1234transId"
+    }
+  ],
+  "stan":"12345stan",
+  "rrn":"12345rrn",
+  "amounts":{
+    "approvedAmount":{
+      "amount":9000,
+      "currency":"710",
+      "ledgerIndicator":"DEBIT"
+    }
+  }
+}

--- a/src/test/resources/messages/models/CardPayment.json
+++ b/src/test/resources/messages/models/CardPayment.json
@@ -1,0 +1,17 @@
+{
+  "type":"CARD",
+  "name":"Card Payment",
+  "amount":{
+    "amount":456,
+    "currency":"710"
+  },
+  "issuer":{
+    "id":"1234InsId",
+    "name":"Institution"
+  },
+  "pin":{
+    "type":"ENCRYPTED_PIN"
+  },
+  "proxy":"12345",
+  "proxyType":"UNKNOWN"
+}

--- a/src/test/resources/messages/models/Customer.json
+++ b/src/test/resources/messages/models/Customer.json
@@ -1,0 +1,18 @@
+{
+  "firstName":"Patrick",
+  "lastName":"Colborne",
+  "address":"41 Sheila Street, Edenvale, Gauteng, 1609",
+  "dateOfBirth":"1995-07-28T00:00:00.000Z",
+  "status":"active",
+  "msisdn":"27762463297",
+  "emailAddress":"pcolborne@gmail.com",
+  "addressDetails":{
+    "addressLine1":"41 Sheila Street",
+    "addressLine2":"Edenvale",
+    "city":"Johannesburg",
+    "province":"Gauteng",
+    "country":"ZA",
+    "postCode":"1609"
+  },
+  "profileId":"188a66d6-166f-4010-9a8e-ea4d3bb22a09"
+}

--- a/src/test/resources/messages/models/Customer.json
+++ b/src/test/resources/messages/models/Customer.json
@@ -10,9 +10,9 @@
     "addressLine1":"41 Sheila Street",
     "addressLine2":"Edenvale",
     "city":"Johannesburg",
-    "province":"Gauteng",
+    "region":"GP",
     "country":"ZA",
-    "postCode":"1609"
+    "postalCode":"1609"
   },
   "profileId":"188a66d6-166f-4010-9a8e-ea4d3bb22a09"
 }

--- a/src/test/resources/messages/models/Originator.json
+++ b/src/test/resources/messages/models/Originator.json
@@ -1,0 +1,3 @@
+{
+  "operatorId":"someOperatorID"
+}

--- a/src/test/resources/messages/models/PinHashed.json
+++ b/src/test/resources/messages/models/PinHashed.json
@@ -1,0 +1,7 @@
+{
+  "type":"HASHED_PIN",
+  "hash":"ABCD",
+  "hashedPinParameters":{
+    "name":"SHA-256"
+  }
+}

--- a/src/test/resources/messages/models/RewardPayment.json
+++ b/src/test/resources/messages/models/RewardPayment.json
@@ -1,0 +1,8 @@
+{
+  "type":"REWARD",
+  "amount":{
+    "amount":456,
+    "currency":"710"
+  },
+  "rewardCode":"EasterPromotions2021"
+}

--- a/src/test/resources/messages/models/WalletPayment.json
+++ b/src/test/resources/messages/models/WalletPayment.json
@@ -1,0 +1,8 @@
+{
+  "type":"WALLET",
+  "amount":{
+    "amount":456,
+    "currency":"710"
+  },
+  "walletId":"0712345678"
+}


### PR DESCRIPTION
I have added a new `Address` model object.

The new `Address` model object is then used to replace the old `address` member variable in the `Customer` model object. The new `Address` type member variable is called `addressDetails`.

I have not made the `Originator` optional in the `Transaction` model object as the [spec](https://electrum.atlassian.net/wiki/spaces/CUS/pages/2731769964/Base+API+Changes) suggests because there seemed to be hesitency to doing so. I think that we should instead create a utility method that can set the `originator` member variable to a known "unknown" originator like:
```
{
    "institution": {
        "id": "99999999",
        "name": "Unknown Institution"
    },
    "terminalId": "99999999",
    "merchant": { /*Some default unknown merchant*/ }
    },
    "operatorId": "999999999999999999999999999999"
}
```