### PR TITLE
The `addressLine` validation constraints in the `Address` object were incorrect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To include this package in your service interface definitions, include the below
 <dependency>
     <groupId>io.electrum</groupId>
     <artifactId>service-interface-base</artifactId>
-    <version>3.30.0</version>
+    <version>3.30.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.30.0</version>
+  <version>3.30.1</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>

--- a/release-notes.md
+++ b/release-notes.md
@@ -14,8 +14,17 @@
     - Try and avoid special characters as far as possible
 -->
 
+## Version 3.30.1 - 30 April 2021
+
+## Bug Fixes
+
+* Validation constraints on `addressLine1` and `addressLine2` of the `Address` model object were incorrect. They were
+  changed from a limit of 250 characters to a limit of 100 characters.
+
 ## Version 3.30.0 - 29 April 2021
+
 ### New Features
+
 * Added new `Address` model object that contains a detailed breakdown of an address.
 * Added new member variables called `addressDetails` and `profileId` to the `Customer` model object.
 * Deprecated the existing `address` member variable as it will be replaced by the new `addressDetails` member variable.

--- a/src/main/java/io/electrum/vas/model/Address.java
+++ b/src/main/java/io/electrum/vas/model/Address.java
@@ -47,7 +47,7 @@ public class Address {
     **/
    @JsonProperty("addressLine1")
    @ApiModelProperty(value = "First line of street address.")
-   @Pattern(regexp="^.{1,250}")
+   @Pattern(regexp="^.{1,100}")
    @Masked
    public String getAddressLine1() {
       return addressLine1;
@@ -69,7 +69,7 @@ public class Address {
     **/
    @JsonProperty("addressLine2")
    @ApiModelProperty(value = "Second line of street address (if required).")
-   @Pattern(regexp="^.{1,250}")
+   @Pattern(regexp="^.{1,100}")
    @Masked
    public String getAddressLine2() {
       return addressLine2;


### PR DESCRIPTION
* Validation constraints on `addressLine1` and `addressLine2` of the `Address` model object were incorrect. They were
  changed from a limit of 250 characters to a limit of 100 characters.