### PR TITLE
masked loyalty card number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>service-interface-base</artifactId>
-  <version>3.33.0</version>
+  <version>3.34.0</version>
   <packaging>jar</packaging>
   <name>Service Interface Base</name>
   <description>Service Interface Base</description>
@@ -45,6 +45,7 @@
     <jaxb-core-version>2.3.0</jaxb-core-version>
     <testng-version>7.0.0</testng-version>
     <mockito-core-version>2.25.0</mockito-core-version>
+    <electrum-message-sdk-version>2.0.0</electrum-message-sdk-version>
     <jacoco.skip>true</jacoco.skip> <!-- skip code coverage unless maven is run with -Djacoco.skip=false -->
     <sonar.coverage.jacoco.xmlReportPaths>
       ${project.reporting.outputDirectory}/jacoco-merged-test-coverage-report/jacoco.xml
@@ -124,6 +125,12 @@
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng-version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.electrum</groupId>
+      <artifactId>electrum-message-sdk</artifactId>
+      <version>${electrum-message-sdk-version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,6 +1,6 @@
 This page describes changes to the Service Interface Base API implemented across different releases of the interface.
 ## 3.34.0
-Released xx July 2021
+Released 15 July 2021
 * Added masking to `LoyaltyCardPayment` card numbers so they are now masked using `MaskPan` annotation.
 
 ## 3.33.0

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,4 +1,8 @@
 This page describes changes to the Service Interface Base API implemented across different releases of the interface.
+## 3.34.0
+Released xx July 2021
+* Added masking to `LoyaltyCardPayment` card numbers so they are now masked using `MaskPan` annotation.
+
 ## 3.33.0
 Released 17 June 2021
 * Added Interface for `HasTenders`. This can be used for creating shared utilities across API implementations.

--- a/src/main/java/io/electrum/vas/model/LoyaltyCardPayment.java
+++ b/src/main/java/io/electrum/vas/model/LoyaltyCardPayment.java
@@ -1,13 +1,17 @@
 package io.electrum.vas.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.electrum.vas.Utils;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.electrum.sdk.masking2.MaskPan;
+import io.electrum.sdk.masking2.Masked;
+import io.electrum.vas.Utils;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(description = "Model for payments made using loyalty programme cards", parent = PaymentMethod.class)
 public class LoyaltyCardPayment extends PaymentMethod {
@@ -20,10 +24,16 @@ public class LoyaltyCardPayment extends PaymentMethod {
       setType(PaymentMethodType.LOYALTY_CARD);
    }
 
+   public LoyaltyCardPayment cardNumber(String cardNumber) {
+      this.cardNumber = cardNumber;
+      return this;
+   }
+
    @ApiModelProperty(required = true, value = "Primary account number of the loyalty programme card used to make a payment")
    @JsonProperty("cardNumber")
    @NotNull
    @Pattern(regexp = "[0-9]{16}")
+   @Masked(MaskPan.class)
    public String getCardNumber() {
       return cardNumber;
    }
@@ -34,9 +44,12 @@ public class LoyaltyCardPayment extends PaymentMethod {
 
    @Override
    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
+      if (this == o)
+         return true;
+      if (o == null || getClass() != o.getClass())
+         return false;
+      if (!super.equals(o))
+         return false;
       LoyaltyCardPayment that = (LoyaltyCardPayment) o;
       return Objects.equals(cardNumber, that.cardNumber);
    }

--- a/src/main/java/io/electrum/vas/model/PaymentMethod.java
+++ b/src/main/java/io/electrum/vas/model/PaymentMethod.java
@@ -128,7 +128,8 @@ public class PaymentMethod {
       return this;
    }
 
-   @ApiModelProperty(value = "The PIN associated with this payment method. Various PIN formats are supported (clear, encrypted, hashed etc.)")
+   @ApiModelProperty(value = "The PIN associated with this payment method. Various PIN formats are supported (clear, "
+         + "encrypted, hashed etc.). NOTE: A pin is not expected in a response and will not be translated.")
    @JsonProperty("pin")
    @Valid
    public Pin getPin() {
@@ -144,8 +145,8 @@ public class PaymentMethod {
       return this;
    }
 
-   @ApiModelProperty(value = "An alternative identifier for the customer's source of funds. Acts as a stand in for " +
-           "the customer identifier. E.g. a customer's MSISDN or email address.")
+   @ApiModelProperty(value = "An alternative identifier for the customer's source of funds. Acts as a stand in for "
+         + "the customer identifier. E.g. a customer's MSISDN or email address.")
    @JsonProperty("proxy")
    @Size(min = 0, max = 40)
    @Masked

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -31,7 +31,8 @@ public class NewModelTests {
    private PaymentMethod walletPayment;
    private PaymentMethod cardPayment;
    private PaymentMethod qrPayment;
-   
+   private PaymentMethod loyaltyCardPayment;
+
    @BeforeMethod
    protected void createPayloads() {
       customer = new Customer()
@@ -119,6 +120,14 @@ public class NewModelTests {
                   .name("Institution"))
             .proxy("12345")
             .proxyType(ProxyType.UNKNOWN);
+
+      loyaltyCardPayment =
+            new LoyaltyCardPayment().cardNumber("1111222233334444")
+                  .amount(new LedgerAmount().amount(100L).currency("710"))
+                  .name("Loyalty Card Payment")
+                  .issuer(new Institution().id("1234InsId").name("Institution"))
+                  .proxy("12345")
+                  .proxyType(ProxyType.UNKNOWN);
    }
 
    @Test(description = "Test we can serialise a model to the expected value.", dataProvider = "serialisedObjectDataProvider")
@@ -176,7 +185,8 @@ public class NewModelTests {
               {walletPayment, JsonUtil.readFileAsString(PayloadFileLocations.WALLET_PAYMENT, false)},
               {cardPayment, JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false)},
               {qrPayment, JsonUtil.readFileAsString(PayloadFileLocations.QR_PAYMENT, false)},
-              {address, JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false)}
+              {address, JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false)},
+              {loyaltyCardPayment, JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false)},
               //@formatter:on
       };
    }
@@ -193,7 +203,8 @@ public class NewModelTests {
               {JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false), cardPayment},
               {JsonUtil.readFileAsString(PayloadFileLocations.QR_PAYMENT, false), qrPayment},
               {JsonUtil.readFileAsString(PayloadFileLocations.CUSTOMER, false), customer},
-              {JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false), address}
+              {JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false), address},
+              {JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false), loyaltyCardPayment}
               //@formatter:on
       };
    }
@@ -213,7 +224,8 @@ public class NewModelTests {
               {walletPayment},
               {cardPayment},
               {qrPayment},
-              {address}
+              {address},
+              {loyaltyCardPayment}
               //@formatter:on
       };
    }
@@ -231,7 +243,8 @@ public class NewModelTests {
               {JsonUtil.readFileAsString(PayloadFileLocations.WALLET_PAYMENT, false), WalletPayment.class},
               {JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false), CardPayment.class},
               {JsonUtil.readFileAsString(PayloadFileLocations.QR_PAYMENT, false), QrPayment.class},
-              {JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false), Address.class}
+              {JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false), Address.class},
+              {JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false), LoyaltyCardPayment.class}
               //@formatter:on
       };
    }
@@ -326,7 +339,8 @@ public class NewModelTests {
                     .region("GP")
                     .country("ZA")
                     .postalCode("1609")},
-              {new WalletPocket().pocketId("12345"), new WalletPocket().pocketId("12345").pocketName("Cash Pocket")}
+              {new WalletPocket().pocketId("12345"), new WalletPocket().pocketId("12345").pocketName("Cash Pocket")},
+              {new LoyaltyCardPayment().cardNumber("abfecc"), loyaltyCardPayment}
               //@formatter:on
       };
    }

--- a/src/test/java/io/electrum/vas/model/NewModelTests.java
+++ b/src/test/java/io/electrum/vas/model/NewModelTests.java
@@ -186,7 +186,7 @@ public class NewModelTests {
               {cardPayment, JsonUtil.readFileAsString(PayloadFileLocations.CARD_PAYMENT, false)},
               {qrPayment, JsonUtil.readFileAsString(PayloadFileLocations.QR_PAYMENT, false)},
               {address, JsonUtil.readFileAsString(PayloadFileLocations.ADDRESS, false)},
-              {loyaltyCardPayment, JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false)},
+              {loyaltyCardPayment, JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false)}
               //@formatter:on
       };
    }

--- a/src/test/java/io/electrum/vas/model/PayloadFileLocations.java
+++ b/src/test/java/io/electrum/vas/model/PayloadFileLocations.java
@@ -13,4 +13,7 @@ public class PayloadFileLocations {
    public static final String QR_PAYMENT = "models/QrPayment.json";
    public static final String CUSTOMER = "models/Customer.json";
    public static final String ADDRESS = "models/Address.json";
+   public static final String LOYALTY_CARD_PAYMENT = "models/LoyaltyCardPayment.json";
+   public static final String LOYALTY_CARD_PAYMENT_MASKED = "models/LoyaltyCardPaymentMasked.json";
+
 }

--- a/src/test/java/io/electrum/vas/model/TestPanMasking.java
+++ b/src/test/java/io/electrum/vas/model/TestPanMasking.java
@@ -1,0 +1,82 @@
+package io.electrum.vas.model;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import io.electrum.sdk.masking2.maskablevalue.MaskableValueSerializer;
+import io.electrum.vas.JsonUtil;
+import io.electrum.vas.util.JsonMaskingBeanSerializerModifier;
+
+public class TestPanMasking {
+   static ObjectMapper objectMapper = new ObjectMapper();
+   private PaymentMethod loyaltyCardPayment;
+
+   static void setupBasicObjectMapper(ObjectMapper objectMapper) {
+      io.electrum.sdk.util.ObjectMapperUtils.setupBasicObjectMapper(objectMapper);
+   }
+
+   static void setupMaskingObjectMapper(ObjectMapper objectMapper) {
+      setupBasicObjectMapper(objectMapper);
+
+      SimpleModule module = new SimpleModule("formattedModule");
+      module.setSerializerModifier(new JsonMaskingBeanSerializerModifier());
+      module.addSerializer(new MaskableValueSerializer());
+      module.addSerializer(new io.electrum.sdk.masking.maskablevalue.MaskableValueSerializer());
+      objectMapper.registerModule(module);
+   }
+
+   @BeforeClass
+   public void setup() {
+      setupMaskingObjectMapper(objectMapper);
+
+      loyaltyCardPayment =
+            new LoyaltyCardPayment().cardNumber("1111222233334444")
+                  .amount(new LedgerAmount().amount(100L).currency("710"))
+                  .name("Loyalty Card Payment")
+                  .issuer(new Institution().id("1234InsId").name("Institution"))
+                  .proxy("12345")
+                  .proxyType(ProxyType.UNKNOWN);
+   }
+
+   @Test(description = "Test we can serialise a model to the expected value when objects are masked.", dataProvider = "maskedSerialisedObjectDataProvider")
+   public void testSerialisedObject(Object objectToSerialise, String expectedValue) throws IOException {
+      String maskedSerializedValue = objectMapper.writeValueAsString(objectToSerialise);
+      Assert.assertEquals(maskedSerializedValue, expectedValue);
+   }
+
+   @Test(description = "Test we can serialise what we deserialised and get a masked string back.", dataProvider = "maskedDeserialiseSerialiseObjectDataProvider")
+   public void testDeserialiseSerialiseObject(String unmaskedValue, String testString, Class<?> classOfObject)
+         throws IOException {
+      Assert.assertEquals(
+            objectMapper.writeValueAsString(objectMapper.readValue(unmaskedValue, classOfObject)),
+            testString);
+   }
+
+   @DataProvider
+   public Object[][] maskedSerialisedObjectDataProvider() throws Exception {
+      return new Object[][] {
+            //@formatter:off
+            { loyaltyCardPayment,
+            JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT_MASKED, false) }
+            //@formatter:on
+      };
+   }
+
+   @DataProvider
+   public Object[][] maskedDeserialiseSerialiseObjectDataProvider() throws Exception {
+      return new Object[][] {
+            //@formatter:off
+            { JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT, false),
+            JsonUtil.readFileAsString(PayloadFileLocations.LOYALTY_CARD_PAYMENT_MASKED, false),
+            LoyaltyCardPayment.class }
+            //@formatter:on
+      };
+   }
+}

--- a/src/test/java/io/electrum/vas/util/JsonMaskingBeanSerializerModifier.java
+++ b/src/test/java/io/electrum/vas/util/JsonMaskingBeanSerializerModifier.java
@@ -1,0 +1,27 @@
+package io.electrum.vas.util;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
+public class JsonMaskingBeanSerializerModifier extends BeanSerializerModifier {
+
+   @Override
+   public List<BeanPropertyWriter> changeProperties(
+         SerializationConfig config,
+         BeanDescription beanDesc,
+         List<BeanPropertyWriter> beanProperties) {
+
+      for (BeanPropertyWriter beanProperty : beanProperties) {
+         io.electrum.sdk.masking2.Masked newMask = beanProperty.getAnnotation(io.electrum.sdk.masking2.Masked.class);
+         if (newMask != null) {
+            beanProperty.assignSerializer(new JsonMaskingSerializer(newMask.value()));
+         }
+      }
+
+      return beanProperties;
+   }
+}

--- a/src/test/java/io/electrum/vas/util/JsonMaskingSerializer.java
+++ b/src/test/java/io/electrum/vas/util/JsonMaskingSerializer.java
@@ -1,0 +1,31 @@
+package io.electrum.vas.util;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import io.electrum.sdk.masking2.Masker;
+
+public class JsonMaskingSerializer extends JsonSerializer<Object> {
+
+    private Class<? extends Masker> maskerClass;
+
+    public JsonMaskingSerializer(Class<? extends Masker> maskerClass) {
+        this.maskerClass = maskerClass;
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException, JsonProcessingException {
+
+        try {
+            Masker masker = maskerClass.newInstance();
+            gen.writeString(masker.mask(value.toString()));
+        } catch (Exception e) {
+            gen.writeString("ERROR");
+        }
+    }
+}

--- a/src/test/resources/messages/models/LoyaltyCardPayment.json
+++ b/src/test/resources/messages/models/LoyaltyCardPayment.json
@@ -1,0 +1,15 @@
+{
+  "type":"LOYALTY_CARD",
+  "name":"Loyalty Card Payment",
+  "amount":{
+    "amount":100,
+    "currency":"710"
+  },
+  "issuer":{
+    "id":"1234InsId",
+    "name":"Institution"
+  },
+  "proxy":"12345",
+  "proxyType":"UNKNOWN",
+  "cardNumber":"1111222233334444"
+}

--- a/src/test/resources/messages/models/LoyaltyCardPaymentMasked.json
+++ b/src/test/resources/messages/models/LoyaltyCardPaymentMasked.json
@@ -1,0 +1,15 @@
+{
+  "type":"LOYALTY_CARD",
+  "name":"Loyalty Card Payment",
+  "amount":{
+    "amount":100,
+    "currency":"710"
+  },
+  "issuer":{
+    "id":"1234InsId",
+    "name":"Institution"
+  },
+  "proxy":"*****",
+  "proxyType":"UNKNOWN",
+  "cardNumber":"111122******4444"
+}


### PR DESCRIPTION
Masked card number for `LoyaltyCardPayment`
Updated description of pin in `PaymentMethod` so customers know we are not expecting it in responses and will therefore not translate it in responses